### PR TITLE
Improve protocol conformance and testing for Codec and Bitrate

### DIFF
--- a/Sources/Types/HLSCore.swift
+++ b/Sources/Types/HLSCore.swift
@@ -92,6 +92,14 @@ public struct Bitrate: Comparable {
     }
 }
 
+extension Bitrate: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: UInt) {
+        self.value = value
+    }
+
+    public typealias IntegerLiteralType = UInt
+}
+
 /** 
  MIME type/subtypes representing different media formats.
  
@@ -99,21 +107,16 @@ public struct Bitrate: Comparable {
  `String`.
  https://tools.ietf.org/html/rfc6381
  */
-public struct Codec: RawRepresentable, Equatable, Hashable, Comparable {
-    //
+public struct Codec: RawRepresentable, Equatable {
     public let rawValue: String
 
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-
-    public static func < (lhs: Codec, rhs: Codec) -> Bool {
-        return lhs.rawValue < rhs.rawValue
-    }
 }
 
 /// EXT-X-STREAM-INF
-public struct StreamInfo {
+public struct StreamInfo: Equatable {
     /// Peak segment bitrate in bits per second
     public let bandwidth: Bitrate
     public let averageBandwidth: Bitrate?

--- a/Tests/TypesTests/HLSCoreTests.swift
+++ b/Tests/TypesTests/HLSCoreTests.swift
@@ -127,3 +127,38 @@ class RenditionGroupTests: XCTestCase {
         ]
     }
 }
+
+
+class StreamInfoTests: XCTestCase {
+
+    func testSorting() {
+        let a = StreamInfo(bandwidth: 1,
+                           averageBandwidth: nil,
+                           codecs: [Codec(rawValue: "h.264")],
+                           resolution: Resolution(width: 3840, height: 2160),
+                           frameRate: 60,
+                           uri: URL(string:"/")!)
+        let b = StreamInfo(bandwidth: 2,
+                           averageBandwidth: nil,
+                           codecs: [Codec(rawValue: "h.264")],
+                           resolution: Resolution(width: 1920, height: 1080),
+                           frameRate: 24,
+                           uri: URL(string:"/")!)
+        let c = StreamInfo(bandwidth: 30,
+                           averageBandwidth: nil,
+                           codecs: [Codec(rawValue: "h.264")],
+                           resolution: Resolution(width: 1280, height: 720),
+                           frameRate: 30,
+                           uri: URL(string:"/")!)
+
+        let bandwidth = [a,b,c].sorted(by: { $0.bandwidth < $1.bandwidth })
+        XCTAssertEqual(bandwidth, [a, b, c])
+
+        let framerate = [a,b,c].sorted(by: { $0.frameRate! < $1.frameRate! })
+        XCTAssertEqual(framerate, [b, c, a])
+
+        let height = [a,b,c].sorted(by: { $0.resolution!.height < $1.resolution!.height })
+        XCTAssertEqual(height, [c, b, a])
+    }
+
+}


### PR DESCRIPTION
* Codec does not need to be Hashable or comparable
* Bitrate can be ExpressibleByIntegerLiteral
* StreamInfo can be Equatible because all its fields are
* Add tests for sortability of StreamInfo on video height and bitrate